### PR TITLE
Fixed issue with Laravel default users table

### DIFF
--- a/database/migrations/create_social_providers_table.php.stub
+++ b/database/migrations/create_social_providers_table.php.stub
@@ -35,7 +35,7 @@ class CreateSocialProvidersTable extends Migration
         Schema::create(
             $table_names['user_has_social_provider'],
             function (Blueprint $table) use ($userTable, $table_names, $foreign_keys) {
-                $table->integer($foreign_keys['users'])->unsigned();
+                $table->bigInteger($foreign_keys['users'])->unsigned();
                 $table->integer('social_provider_id')->unsigned();
                 $table->string('token');
                 $table->string($foreign_keys['socials']);


### PR DESCRIPTION
## Description

I see that you added support for Laravel 6.x, which use per default bigInteger for `users.id`

So also foreign key `user_has_social_provider.user_id` must be bigInteger, otherwise happen this issue:

 > SQLSTATE[HY000]: General error: 1215 Cannot add foreign key constraint (SQL: alter table `user_has_social_provider` add constraint `user_has_social_provider_user_id_foreign` foreign key (`user_id`) references `users` (`id`) on delete cascade)

## Motivation and context

Support for Laravel 6.x

## How has this been tested?

Just run migrate 

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
